### PR TITLE
Create react app through yarn, not npx

### DIFF
--- a/one-time-project-setup.md
+++ b/one-time-project-setup.md
@@ -25,7 +25,7 @@ Clone the forked repo. Do _not_ clone this inside of another project folder, bec
 Create a new React app within this project folder. **You must perform this within this front-end project folder**.
 
 ```bash
-$ npx create-react-app .
+$ yarn create react-app .
 ```
 
 ## Add `axios`


### PR DESCRIPTION
## Previously
We create a react app using `npx`, which is a part of `npm`. 

## After this change

Now we use `yarn`! Space between `create` and `react-app` instead of dash is intentional, [see yarn command in the official create-react-app docs](https://create-react-app.dev/docs/getting-started/).